### PR TITLE
Draft 16 Updates

### DIFF
--- a/common.props
+++ b/common.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>0.15.3</Version>
+        <Version>0.16.0</Version>
 
         <Authors>Unify Square (a Unisys company)</Authors>
         <Product>NSign</Product>

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.cs
@@ -48,6 +48,25 @@ namespace NSign.AspNetCore
         }
 
         [Theory]
+        [InlineData("https", 443, "localhost")]
+        [InlineData("http", 80, "localhost")]
+        [InlineData("https", null, "localhost")]
+        [InlineData("http", null, "localhost")]
+        [InlineData("https", 8443, "localhost:8443")]
+        [InlineData("http", 8080, "localhost:8080")]
+        public void GetDerivedComponentValueReturnsNormalizedAuthority(string scheme, int? port, string expectedValue)
+        {
+            HttpRequest? request = httpContext.Request;
+            request.Scheme = scheme;
+            request.Host = port.HasValue ? new HostString("localhost", port.Value) : new HostString("localhost");
+
+            DerivedComponent comp = new DerivedComponent("@authority");
+            string actualValue = httpContext.Request.GetDerivedComponentValue(comp);
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Theory]
         [InlineData(null, "?")]
         [InlineData("", "?")]
         [InlineData("?", "?")]

--- a/test/NSign.Client.UnitTests/Client/HttpRequestMessageContextTests.cs
+++ b/test/NSign.Client.UnitTests/Client/HttpRequestMessageContextTests.cs
@@ -106,6 +106,29 @@ namespace NSign.Client
         }
 
         [Theory]
+        [InlineData("https", 443, "localhost")]
+        [InlineData("http", 80, "localhost")]
+        [InlineData("https", null, "localhost")]
+        [InlineData("http", null, "localhost")]
+        [InlineData("https", 8443, "localhost:8443")]
+        [InlineData("http", 8080, "localhost:8080")]
+        public void GetDerivedComponentValueReturnsNormalizedAuthority(string scheme, int? port, string expectedValue)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(
+                HttpMethod.Options, $"{scheme}://localhost{(port.HasValue ? ":" + port : "")}/test");
+            HttpRequestMessageContext context = new HttpRequestMessageContext(mockLogger.Object,
+                                                                              httpFieldOptions,
+                                                                              request,
+                                                                              cancellationTokenSource.Token,
+                                                                              signingOptions);
+
+            DerivedComponent comp = new DerivedComponent("@authority");
+            string? actualValue = context.GetDerivedComponentValue(comp);
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Theory]
         [InlineData("not-found", new string[0])]
         [InlineData("x-first-header", new string[] { "firstValue" })]
         [InlineData("x-second-header", new string[] { "" })]

--- a/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
@@ -37,6 +37,30 @@ namespace NSign.Providers
         }
 
         [Fact]
+        public async Task Standard_4_3_Verify_OnReverseProxy_Draft16()
+        {
+            ECDsaP256Sha256SignatureProvider provider = Make(false, "test-key-ecc-p256", "test-key-ecc-p256");
+
+            string input =
+                "\"@method\": POST\n" +
+                "\"@authority\": example.com\n" +
+                "\"@path\": /foo\n" +
+                "\"content-digest\": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"content-length\": 18\n" +
+                "\"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\");created=1618884475;keyid=\"test-key-ecc-p256\"";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\");created=1618884475;keyid=\"test-key-ecc-p256\"");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String("hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
+        [Fact]
         public async Task Standard_B_2_4_Verify()
         {
             ECDsaP256Sha256SignatureProvider provider = Make(false, "test-key-ecc-p256", "test-key-ecc-p256");

--- a/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
@@ -54,6 +54,46 @@ namespace NSign.Providers
         }
 
         [Fact]
+        public async Task Standard_4_3_Sign_Updated_Draft16()
+        {
+            RsaPkcs15Sha256SignatureProvider provider = Make(true, "test-key-rsa", "test-key-rsa");
+
+            string input =
+                "\"signature\";key=\"sig1\": :hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:\n" +
+                "\"@authority\": origin.host.internal.example\n" +
+                "\"forwarded\": for=192.0.2.123\n" +
+                "\"@signature-params\": (\"signature\";key=\"sig1\" \"@authority\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540";
+
+            ReadOnlyMemory<byte> signature = await provider.SignAsync(Encoding.ASCII.GetBytes(input), default);
+            string sigBase64 = Convert.ToBase64String(signature.Span);
+            Assert.Equal(
+                "YvYVO11F+Q+N4WZNeBdjFKluswwE3vQ4cTXpBwEiMz2hwu0J+wSJLRhHlIZ1N83epfnKDxY9cbNaVlbtr2UOLkw5O5Q5M5yrjx3s1mgDOsV7fuItD6iDyNISCiKRuevl+M+TyYBo10ubG83As5CeeoUdmrtI4G6QX7RqEeX0Xj/CYofHljr/dVzARxskjHEQbTztYVg4WD+LWo1zjx9w5fw26tsOMagfXLpDb4zb4/lgpgyNKoXFwG7c89KId5q+0BC+kryWuA35ZcQGaRPAz/NqzeKq/c7p7b/fmHS71fy1jOaFgWFmD+Z77bJLO8AVKuF0y2fpL3KUYHyITQHOsA==",
+                sigBase64);
+        }
+
+        [Fact]
+        public async Task Standard_4_3_Verify_Updated_Draft16()
+        {
+            RsaPkcs15Sha256SignatureProvider provider = Make(false, "test-key-rsa", "test-key-rsa");
+
+            string input =
+                "\"signature\";key=\"sig1\": :hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:\n" +
+                "\"@authority\": origin.host.internal.example\n" +
+                "\"forwarded\": for=192.0.2.123\n" +
+                "\"@signature-params\": (\"signature\";key=\"sig1\" \"@authority\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"signature\";key=\"sig1\" \"@authority\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String(
+                    "YvYVO11F+Q+N4WZNeBdjFKluswwE3vQ4cTXpBwEiMz2hwu0J+wSJLRhHlIZ1N83epfnKDxY9cbNaVlbtr2UOLkw5O5Q5M5yrjx3s1mgDOsV7fuItD6iDyNISCiKRuevl+M+TyYBo10ubG83As5CeeoUdmrtI4G6QX7RqEeX0Xj/CYofHljr/dVzARxskjHEQbTztYVg4WD+LWo1zjx9w5fw26tsOMagfXLpDb4zb4/lgpgyNKoXFwG7c89KId5q+0BC+kryWuA35ZcQGaRPAz/NqzeKq/c7p7b/fmHS71fy1jOaFgWFmD+Z77bJLO8AVKuF0y2fpL3KUYHyITQHOsA=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
+        [Fact]
         public async Task Standard_4_3_Verify_PublicKeyOnly()
         {
             RsaPkcs15Sha256SignatureProvider provider = new RsaPkcs15Sha256SignatureProvider(null, publicKeyFromStandard, "test-key-rsa");


### PR DESCRIPTION
- Make sure the `@authority` derived component values are normalized before use.
- Add more sample signatures from draft to tests.