### PR TITLE
Updates for draft 17

### DIFF
--- a/common.props
+++ b/common.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>0.16.0</Version>
+        <Version>0.17.0</Version>
 
         <Authors>Unify Square (a Unisys company)</Authors>
         <Product>NSign</Product>

--- a/examples/Publisher/Program.cs
+++ b/examples/Publisher/Program.cs
@@ -24,15 +24,15 @@ static void SetupServices(IServiceCollection services)
         {
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("NSignExample.Publisher", "0.1"));
         })
-        .AddDigestAndSigningHandlers()
+        .AddContentDigestAndSigningHandlers()
         .Services
 
-        .Configure<AddDigestOptions>(options => options.WithHash(AddDigestOptions.Hash.Sha256))
+        .Configure<AddContentDigestOptions>(options => options.WithHash(AddContentDigestOptions.Hash.Sha256))
         .ConfigureMessageSigningOptions(options =>
         {
             options.SignatureName = "pubsig";
             options
-                .WithMandatoryComponent(SignatureComponent.Digest)
+                .WithMandatoryComponent(SignatureComponent.ContentDigest)
                 .WithMandatoryComponent(new HttpHeaderStructuredFieldComponent(Constants.Headers.ContentType))
                 .WithOptionalComponent(SignatureComponent.ContentLength)
                 .SetParameters = (signingOptions) => signingOptions

--- a/examples/Publisher/packages.lock.json
+++ b/examples/Publisher/packages.lock.json
@@ -289,8 +289,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -369,7 +369,7 @@
           "Microsoft.Extensions.Http": "[6.0.*, )",
           "Microsoft.Extensions.Logging.Abstractions": "[6.0.*, )",
           "Microsoft.Extensions.Options": "[6.0.*, )",
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )",
           "System.Collections.Immutable": "[6.0.*, )",
           "System.IO.Pipelines": "[6.*, )"
@@ -378,7 +378,7 @@
       "nsign.signatureproviders": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )"
+          "NSign.Abstractions": "[0.17.0, )"
         }
       }
     }

--- a/examples/Subscriber/Program.cs
+++ b/examples/Subscriber/Program.cs
@@ -8,12 +8,12 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddControllers().Services
-    .Configure<DigestVerificationOptions>(o =>
-        o.Behavior |= DigestVerificationOptions.VerificationBehavior.RequireOnlySingleMatch)
+    .Configure<ContentDigestVerificationOptions>(o =>
+        o.Behavior |= ContentDigestVerificationOptions.VerificationBehavior.RequireOnlySingleMatch)
     .Configure<RequestSignatureVerificationOptions>((options) =>
     {
         options.TagsToVerify.Add("nsign-example-publisher");
-        options.RequiredSignatureComponents.Add(SignatureComponent.Digest);
+        options.RequiredSignatureComponents.Add(SignatureComponent.ContentDigest);
         options.RequiredSignatureComponents.Add(new HttpHeaderStructuredFieldComponent(Constants.Headers.ContentType));
         options.CreatedRequired =
             options.ExpiresRequired =
@@ -32,7 +32,7 @@ builder.Services
     })
     .AddSignatureVerification(
         new RsaPssSha512SignatureProvider(new X509Certificate2(@"examples.nsign.local.cer"), "examples.nsign.local"))
-    .AddDigestVerification()
+    .AddContentDigestVerification()
     ;
 
 var app = builder.Build();
@@ -46,5 +46,5 @@ app.Run();
 
 static void ValidateSignatureAndDigest(IApplicationBuilder builder)
 {
-    builder.UseSignatureVerification().UseDigestVerification();
+    builder.UseSignatureVerification().UseContentDigestVerification();
 }

--- a/examples/Subscriber/packages.lock.json
+++ b/examples/Subscriber/packages.lock.json
@@ -41,8 +41,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -83,14 +83,14 @@
       "nsign.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )"
         }
       },
       "nsign.signatureproviders": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )"
+          "NSign.Abstractions": "[0.17.0, )"
         }
       }
     }

--- a/src/NSign.Abstractions/Constants.cs
+++ b/src/NSign.Abstractions/Constants.cs
@@ -23,7 +23,7 @@
             /// <summary>
             /// The name of the header holding message body digest values.
             /// </summary>
-            public const string Digest = "digest";
+            public const string ContentDigest = "content-digest";
 
             /// <summary>
             /// The name of the header holding message body content type.

--- a/src/NSign.Abstractions/Http/PercentCodec.cs
+++ b/src/NSign.Abstractions/Http/PercentCodec.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NSign.Http
+{
+    /// <summary>
+    /// Percent-encoding encoder/decoder. Does percent-encoding according to <see href="https://url.spec.whatwg.org/"/>
+    /// </summary>
+    public static class PercentCodec
+    {
+        /// <summary>
+        /// Regex to match all characters that need percent encoding. This is the set of all non-ASCII code points, as
+        /// well as ASCII code points except alpha-numeric ASCII plus '*', '-', '.', '_'. Thus, it's easier to create
+        /// a regular expression that is based on the code points that do <b>not</b> require encoding.
+        /// </summary>
+        private static readonly Regex EncodingNeeded = new Regex("[^a-zA-Z0-9*\\-._]", RegexOptions.Singleline);
+
+        /// <summary>
+        /// Pre-calculated replacement strings for percent encoding of individual byte values.
+        /// </summary>
+        private static readonly string[] ByteEncoding = Enumerable.Range(0, 255)
+            .Select(b => $"%{b.ToString("X2")}").ToArray();
+
+        /// <summary>
+        /// Encode the given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">
+        /// The value to encode.
+        /// </param>
+        /// <returns>
+        /// The percent-encoded value.
+        /// </returns>
+        public static string Encode(string value)
+        {
+            return Encode(value, decodeFirst: false);
+        }
+
+        /// <summary>
+        /// Encode the given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">
+        /// The value to encode. The value is first decoded (through <see cref="Uri.UnescapeDataString"/>) to ensure
+        /// already escaped code points are not double-escaped.
+        /// </param>
+        /// <param name="decodeFirst">
+        /// A flag that indicates whether to decode the value first.
+        /// </param>
+        /// <returns>
+        /// The percent-encoded value.
+        /// </returns>
+        public static string Encode(string value, bool decodeFirst)
+        {
+            if (decodeFirst)
+            {
+                value = Uri.UnescapeDataString(value);
+            }
+
+            return EncodingNeeded.Replace(value, Encode);
+        }
+
+        /// <summary>
+        /// Encode the character matched by the <see cref="EncodingNeeded"/> regex.
+        /// </summary>
+        /// <param name="match">
+        /// The <see cref="Match"/> to percent encode.
+        /// </param>
+        /// <returns>
+        /// The encoded value from the match.
+        /// </returns>
+        private static string Encode(Match match)
+        {
+            Span<byte> bytes = stackalloc byte[8]; // It should be safe to assume at most 8 bytes per code-point.
+            int numBytes = Encoding.UTF8.GetBytes(match.Value, bytes);
+            StringBuilder result = new StringBuilder(numBytes * 3);
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                result.Append(ByteEncoding[bytes[i]]);
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
@@ -182,6 +182,12 @@ namespace NSign.Signatures
                 {
                     throw new SignatureComponentMissingException(queryParam);
                 }
+                else if (1 < numValues)
+                {
+                    throw new SignatureComponentNotAllowedException(
+                        $"Query parameter '{queryParam.Name}' has more than one value which is not allowed in signatures.",
+                        queryParam);
+                }
             }
 
             #region Private Methods
@@ -243,7 +249,8 @@ namespace NSign.Signatures
                         }
                         else if (component is ISignatureComponentWithName componentWithName)
                         {
-                            sb.Append($"{prefix};{Constants.ComponentParameters.Name}=\"{componentWithName.Name}\"");
+                            sb.Append($"{prefix};{Constants.ComponentParameters.Name}=" +
+                                $"\"{PercentCodec.Encode(componentWithName.Name)}\"");
                         }
                         else if (component is HttpHeaderStructuredFieldComponent)
                         {
@@ -372,7 +379,10 @@ namespace NSign.Signatures
                 if (null == component.OriginalIdentifier)
                 {
                     string suffix = component.BindRequest ? ParamBindRequest : String.Empty;
-                    AddInput($"\"{component.ComponentName}\"{suffix};{Constants.ComponentParameters.Name}=\"{component.Name}\"", value);
+                    AddInput($"\"{component.ComponentName}\"{suffix};" +
+                        $"{Constants.ComponentParameters.Name}=" +
+                        $"\"{PercentCodec.Encode(component.Name)}\"",
+                        PercentCodec.Encode(value));
                 }
                 else
                 {

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
@@ -95,7 +95,7 @@ namespace NSign.Signatures
             /// <inheritdoc/>
             public override void Visit(QueryParamComponent queryParam)
             {
-                Found &= context.HasQueryParam(queryParam.Name);
+                Found &= context.HasExactlyOneQueryParamValue(queryParam.Name);
             }
 
             /// <summary>

--- a/src/NSign.Abstractions/Signatures/MessageContext.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.cs
@@ -333,7 +333,7 @@ namespace NSign.Signatures
         {
             if (component is QueryParamComponent queryParam)
             {
-                return HasQueryParam(queryParam.Name);
+                return HasExactlyOneQueryParamValue(queryParam.Name);
             }
 
             if (HasResponse)
@@ -354,17 +354,22 @@ namespace NSign.Signatures
         }
 
         /// <summary>
-        /// Checks if a query parameter with the given <paramref name="paramName"/> is available on the request URL.
+        /// Checks if a query parameter with the given <paramref name="paramName"/> is available on the request URL and
+        /// has exactly one value.
         /// </summary>
         /// <param name="paramName">
         /// The name of the query parameter to check.
         /// </param>
         /// <returns>
-        /// True if the query parameter exists, false otherwise.
+        /// True if the query parameter exists and has exactly one value, false otherwise.
         /// </returns>
-        public virtual bool HasQueryParam(string paramName)
+        public virtual bool HasExactlyOneQueryParamValue(string paramName)
         {
-            return GetQueryParamValues(paramName).Any();
+            IEnumerable<string> values = GetQueryParamValues(paramName);
+            using IEnumerator<string> enumerator = values.GetEnumerator();
+
+            // We have exactly one value if we can move the enumerator once (to the first element), but not beyond that.
+            return enumerator.MoveNext() && !enumerator.MoveNext();
         }
 
         /// <summary>

--- a/src/NSign.Abstractions/Signatures/QueryParamComponent.cs
+++ b/src/NSign.Abstractions/Signatures/QueryParamComponent.cs
@@ -35,7 +35,10 @@ namespace NSign.Signatures
                 throw new ArgumentNullException(nameof(name));
             }
 
-            Name = name.ToLower();
+            // When the component is created by the parser, the name would have
+            // to be percent encoded. So in order to work with the decoded name
+            // we need to decode it here first.
+            Name = Uri.UnescapeDataString(name);
         }
 
         #region ISignatureComponentWithName Implementation

--- a/src/NSign.Abstractions/Signatures/SignatureComponent.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureComponent.cs
@@ -52,9 +52,9 @@ namespace NSign.Signatures
         public static readonly DerivedComponent Status = new DerivedComponent(Constants.DerivedComponents.Status);
 
         /// <summary>
-        /// Represents the 'Digest' HTTP header component.
+        /// Represents the 'Content-Digest' HTTP header component.
         /// </summary>
-        public static readonly HttpHeaderComponent Digest = new HttpHeaderComponent(Constants.Headers.Digest);
+        public static readonly HttpHeaderComponent ContentDigest = new HttpHeaderComponent(Constants.Headers.ContentDigest);
 
         /// <summary>
         /// Represents the 'Content-Type' HTTP header component.

--- a/src/NSign.Abstractions/Signatures/SignatureInputParser.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureInputParser.cs
@@ -279,7 +279,11 @@ namespace NSign.Signatures
                     {
                         throw new SignatureInputException("The @query-param component requires the 'name' parameter.");
                     }
-                    signatureParams.AddComponent(new QueryParamComponent(name, bindRequest));
+                    signatureParams.AddComponent(
+                        new QueryParamComponent(name, bindRequest)
+                        {
+                            OriginalIdentifier = new String(originalIdentifier),
+                        });
                     break;
 
                 // Handle known cases without parameters too, so we can reuse existing components rather than creating more.
@@ -359,7 +363,6 @@ namespace NSign.Signatures
             TryGetParameterValue(componentParams, Constants.ComponentParameters.ByteSequence, out bool useByteSequence);
 
             string original = new String(originalIdentifier);
-
 
             if (TryGetParameterValue(componentParams, Constants.ComponentParameters.Key, out string key))
             {

--- a/src/NSign.Abstractions/Signatures/SignatureParamsComponent.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureParamsComponent.cs
@@ -108,6 +108,12 @@ namespace NSign.Signatures
                 throw new InvalidOperationException("Cannot add a '@signature-params' component to a SignatureParamsComponent.");
             }
 
+            if (components.Contains(component))
+            {
+                throw new InvalidOperationException($"The component '{component}' has already been added. " +
+                    "Adding the same component twice is not allowed");
+            }
+
             components.Add(component);
 
             return this;

--- a/src/NSign.Abstractions/packages.lock.json
+++ b/src/NSign.Abstractions/packages.lock.json
@@ -36,8 +36,8 @@
       "StructuredFieldValues": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }

--- a/src/NSign.AspNetCore/AspNetCore/ContentDigestVerificationOptions.cs
+++ b/src/NSign.AspNetCore/AspNetCore/ContentDigestVerificationOptions.cs
@@ -5,15 +5,15 @@ namespace NSign.AspNetCore
     /// <summary>
     /// Options class to control digest verification on HTTP request messages.
     /// </summary>
-    public sealed class DigestVerificationOptions
+    public sealed class ContentDigestVerificationOptions
     {
         /// <summary>
-        /// Gets or sets the HTTP status code to use when the 'digest' header is missing. Defauls to <c>400</c>;
+        /// Gets or sets the HTTP status code to use when the 'content-digest' header is missing. Defauls to <c>400</c>;
         /// </summary>
         public int MissingHeaderResponseStatus { get; set; } = 400;
 
         /// <summary>
-        /// Gets or sets the HTTP status code to use when 'digest' header value verification has failed. Defauls to <c>400</c>;
+        /// Gets or sets the HTTP status code to use when 'content-digest' header value verification has failed. Defauls to <c>400</c>;
         /// </summary>
         public int VerificationFailuresResponseStatus { get; set; } = 400;
 
@@ -45,7 +45,7 @@ namespace NSign.AspNetCore
             RequireOnlySingleMatch = 0x10,
 
             /// <summary>
-            /// The 'Digest' header is not required; it's verified only when present.
+            /// The 'Content-Digest' header is not required; it's verified only when present.
             /// </summary>
             Optional = 0x0100,
         }

--- a/src/NSign.AspNetCore/AspNetCore/RequestMessageContext.cs
+++ b/src/NSign.AspNetCore/AspNetCore/RequestMessageContext.cs
@@ -195,9 +195,10 @@ namespace NSign.AspNetCore
         }
 
         /// <inheritdoc/>
-        public override sealed bool HasQueryParam(string paramName)
+        public override sealed bool HasExactlyOneQueryParamValue(string paramName)
         {
-            return HttpContext.Request.Query.ContainsKey(paramName);
+            return HttpContext.Request.Query.TryGetValue(paramName, out StringValues values)
+                && values.Count == 1;
         }
 
         #endregion

--- a/src/NSign.AspNetCore/DependencyInjectionExtensions.cs
+++ b/src/NSign.AspNetCore/DependencyInjectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         #region Digest Verification Middleware
 
         /// <summary>
-        /// Adds the <see cref="DigestVerificationMiddleware"/> to the request pipeline.
+        /// Adds the <see cref="ContentDigestVerificationMiddleware"/> to the request pipeline.
         /// </summary>
         /// <param name="app">
         /// The <see cref="IApplicationBuilder"/> instance.
@@ -22,13 +22,13 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>
         /// The <see cref="IApplicationBuilder"/> instance.
         /// </returns>
-        public static IApplicationBuilder UseDigestVerification(this IApplicationBuilder app)
+        public static IApplicationBuilder UseContentDigestVerification(this IApplicationBuilder app)
         {
-            return app.UseMiddleware<DigestVerificationMiddleware>();
+            return app.UseMiddleware<ContentDigestVerificationMiddleware>();
         }
 
         /// <summary>
-        /// Adds the <see cref="DigestVerificationMiddleware"/> as a transient service.
+        /// Adds the <see cref="ContentDigestVerificationMiddleware"/> as a transient service.
         /// </summary>
         /// <param name="services">
         /// The <see cref="IServiceCollection"/> instance.
@@ -36,9 +36,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>
         /// The <see cref="IServiceCollection"/> instance.
         /// </returns>
-        public static IServiceCollection AddDigestVerification(this IServiceCollection services)
+        public static IServiceCollection AddContentDigestVerification(this IServiceCollection services)
         {
-            return services.AddTransient<DigestVerificationMiddleware>();
+            return services.AddTransient<ContentDigestVerificationMiddleware>();
         }
 
         #endregion

--- a/src/NSign.AspNetCore/packages.lock.json
+++ b/src/NSign.AspNetCore/packages.lock.json
@@ -5,8 +5,8 @@
       "StructuredFieldValues": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -86,8 +86,8 @@
       "StructuredFieldValues": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }

--- a/src/NSign.Client/Client/AddContentDigestHandler.cs
+++ b/src/NSign.Client/Client/AddContentDigestHandler.cs
@@ -7,28 +7,28 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static NSign.Client.AddDigestOptions;
+using static NSign.Client.AddContentDigestOptions;
 
 namespace NSign.Client
 {
     /// <summary>
-    /// Implements a <see cref="DelegatingHandler"/> that adds <c>Digest</c> headers with hashes for request bodies to
-    /// outgoing requests.
+    /// Implements a <see cref="DelegatingHandler"/> that adds <c>Content-Digest</c> headers with hashes for request
+    /// bodies to outgoing requests.
     /// </summary>
-    public sealed class AddDigestHandler : DelegatingHandler
+    public sealed class AddContentDigestHandler : DelegatingHandler
     {
         /// <summary>
-        /// The IOptions of AddDigestOptions defining which hashes to add.
+        /// The IOptions of <see cref="AddContentDigestOptions"/> defining which hashes to add.
         /// </summary>
-        private readonly IOptions<AddDigestOptions> options;
+        private readonly IOptions<AddContentDigestOptions> options;
 
         /// <summary>
-        /// Initializes a new instance of AddDigestHandler.
+        /// Initializes a new instance of <see cref="AddContentDigestHandler"/>.
         /// </summary>
         /// <param name="options">
-        /// The IOptions of AddDigestOptions defining which hashes to add.
+        /// The IOptions of <see cref="AddContentDigestOptions"/> defining which hashes to add.
         /// </param>
-        public AddDigestHandler(IOptions<AddDigestOptions> options)
+        public AddContentDigestHandler(IOptions<AddContentDigestOptions> options)
         {
             this.options = options;
         }
@@ -36,13 +36,13 @@ namespace NSign.Client
         /// <inheritdoc/>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            AddDigestOptions options = this.options.Value;
+            AddContentDigestOptions options = this.options.Value;
 
             if (null != request.Content)
             {
                 foreach (Hash hash in options.Hashes)
                 {
-                    request.Content.Headers.Add(Constants.Headers.Digest, await GetDigestValueAsync(request.Content, hash));
+                    request.Content.Headers.Add(Constants.Headers.ContentDigest, await GetDigestValueAsync(request.Content, hash));
                 }
             }
 
@@ -50,7 +50,7 @@ namespace NSign.Client
         }
 
         /// <summary>
-        /// Gets the digest header value for the given content and hashAlgorithm asynchronously.
+        /// Gets the 'content-digest' header value for the given content and hashAlgorithm asynchronously.
         /// </summary>
         /// <param name="content">
         /// The HttpContext object describing the content to hash.
@@ -59,7 +59,7 @@ namespace NSign.Client
         /// The Hash algorithm to use for hashing.
         /// </param>
         /// <returns>
-        /// A string value that represents the value for the 'Digest' for the content.
+        /// A string value that represents the value for the 'Content-Digest' for the content.
         /// </returns>
         private static Task<string> GetDigestValueAsync(HttpContent content, Hash hashAlgorithm)
         {
@@ -80,13 +80,13 @@ namespace NSign.Client
         }
 
         /// <summary>
-        /// Gets the HashAlgorithm and the corresponding name for the 'Digest' header.
+        /// Gets the HashAlgorithm and the corresponding name for the 'Content-Digest' header.
         /// </summary>
         /// <param name="alg">
-        /// The Hash value that defines which hash algorithm to use for the 'Digest' header.
+        /// The Hash value that defines which hash algorithm to use for the 'Content-Digest' header.
         /// </param>
         /// <param name="algName">
-        /// If successful, holds the name of the hash algorithm to be used as the key for the 'Digest' header value.
+        /// If successful, holds the name of the hash algorithm to be used as the key for the 'Content-Digest' header value.
         /// </param>
         /// <returns>
         /// An instance of HashAlgorithm that can be used to hash the request body.

--- a/src/NSign.Client/Client/AddContentDigestOptions.cs
+++ b/src/NSign.Client/Client/AddContentDigestOptions.cs
@@ -4,25 +4,25 @@ using System.Collections.ObjectModel;
 namespace NSign.Client
 {
     /// <summary>
-    /// Options class to control the creation/adding of 'Digest' headers for outgoing messages.
+    /// Options class to control the creation/adding of 'Content-Digest' headers for outgoing messages.
     /// </summary>
-    public sealed class AddDigestOptions
+    public sealed class AddContentDigestOptions
     {
         /// <summary>
-        /// Gets an ICollection of <see cref="Hash"/> values defining the hash algorithms to use for the 'Digest' header.
+        /// Gets an ICollection of <see cref="Hash"/> values defining the hash algorithms to use for the 'Content-Digest' header.
         /// </summary>
         public ICollection<Hash> Hashes { get; } = new Collection<Hash>();
 
         /// <summary>
-        /// Instructs the <see cref="AddDigestHandler"/> to add the given <see cref="Hash"/> to the 'Digest' header.
+        /// Instructs the <see cref="AddContentDigestHandler"/> to add the given <see cref="Hash"/> to the 'Content-Digest' header.
         /// </summary>
         /// <param name="hash">
-        /// The <see cref="Hash"/> value defining the hash algorithm to create a 'Digest' header value for.
+        /// The <see cref="Hash"/> value defining the hash algorithm to create a 'Content-Digest' header value for.
         /// </param>
         /// <returns>
-        /// The <see cref="AddDigestOptions"/> instance.
+        /// The <see cref="AddContentDigestOptions"/> instance.
         /// </returns>
-        public AddDigestOptions WithHash(Hash hash)
+        public AddContentDigestOptions WithHash(Hash hash)
         {
             Hashes.Add(hash);
 

--- a/src/NSign.Client/Client/HttpRequestMessageContext.cs
+++ b/src/NSign.Client/Client/HttpRequestMessageContext.cs
@@ -154,9 +154,10 @@ namespace NSign.Client
         }
 
         /// <inheritdoc/>
-        public override sealed bool HasQueryParam(string paramName)
+        public override sealed bool HasExactlyOneQueryParamValue(string paramName)
         {
-            return null != queryParams.Value.GetValues(paramName);
+            string[] values = queryParams.Value.GetValues(paramName);
+            return null != values && 1 == values.Length;
         }
 
         #endregion

--- a/src/NSign.Client/DependencyInjectionExtensions.cs
+++ b/src/NSign.Client/DependencyInjectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class DependencyInjectionExtensions
     {
         /// <summary>
-        /// Adds the <see cref="AddDigestHandler"/> message handler to the HTTP client.
+        /// Adds the <see cref="AddContentDigestHandler"/> message handler to the HTTP client.
         /// </summary>
         /// <param name="clientBuilder">
         /// The <see cref="IHttpClientBuilder"/>.
@@ -17,11 +17,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>
         /// An <see cref="IHttpClientBuilder"/> that can be used to configure the client.
         /// </returns>
-        public static IHttpClientBuilder AddDigestHandler(this IHttpClientBuilder clientBuilder)
+        public static IHttpClientBuilder AddContentDigestHandler(this IHttpClientBuilder clientBuilder)
         {
-            clientBuilder.Services.AddTransient<AddDigestHandler>();
+            clientBuilder.Services.AddTransient<AddContentDigestHandler>();
 
-            return clientBuilder.AddHttpMessageHandler<AddDigestHandler>();
+            return clientBuilder.AddHttpMessageHandler<AddContentDigestHandler>();
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds both the <see cref="AddDigestHandler"/> and the <see cref="SigningHandler"/> message handlers to the HTTP
+        /// Adds both the <see cref="AddContentDigestHandler"/> and the <see cref="SigningHandler"/> message handlers to the HTTP
         /// client, in that order.
         /// </summary>
         /// <param name="clientBuilder">
@@ -53,10 +53,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>
         /// An <see cref="IHttpClientBuilder"/> that can be used to configure the client.
         /// </returns>
-        public static IHttpClientBuilder AddDigestAndSigningHandlers(this IHttpClientBuilder clientBuilder)
+        public static IHttpClientBuilder AddContentDigestAndSigningHandlers(this IHttpClientBuilder clientBuilder)
         {
             // Digest must come before signing to make sure signing also has the 'Digest' header available.
-            return clientBuilder.AddDigestHandler().AddSigningHandler();
+            return clientBuilder.AddContentDigestHandler().AddSigningHandler();
         }
 
         /// <summary>

--- a/src/NSign.Client/packages.lock.json
+++ b/src/NSign.Client/packages.lock.json
@@ -37,8 +37,8 @@
       "StructuredFieldValues": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }

--- a/src/NSign.SignatureProviders/packages.lock.json
+++ b/src/NSign.SignatureProviders/packages.lock.json
@@ -46,8 +46,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }

--- a/test/NSign.Abstractions.UnitTests/Http/PercentCodecTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Http/PercentCodecTests.cs
@@ -1,0 +1,37 @@
+﻿using Xunit;
+
+namespace NSign.Http
+{
+    public sealed class PercentCodecTests
+    {
+        [Theory]
+        [InlineData("\x23", "%23")]
+        [InlineData("\x7f", "%7F")]
+        [InlineData("≡", "%E2%89%A1")]
+        [InlineData("‽", "%E2%80%BD")]
+        [InlineData("Say what‽", "Say%20what%E2%80%BD")]
+        [InlineData("abcABC0123*-._", "abcABC0123*-._")]
+        [InlineData("abc+def", "abc%2Bdef")]
+        public void EncodeWorks(string input, string expectedOutput)
+        {
+            Assert.Equal(expectedOutput, PercentCodec.Encode(input));
+        }
+
+        [Theory]
+        [InlineData("\x23", "%23")]
+        [InlineData("\x7f", "%7F")]
+        [InlineData("≡", "%E2%89%A1")]
+        [InlineData("‽", "%E2%80%BD")]
+        [InlineData("Say what‽", "Say%20what%E2%80%BD")]
+        [InlineData("abcABC0123*-._", "abcABC0123*-._")]
+        [InlineData("abc+def", "abc%2Bdef")]
+        public void EncodeWithDecodeFirstWorks(string input, string expectedOutput)
+        {
+            string encoded = PercentCodec.Encode(input, decodeFirst: true);
+            Assert.Equal(expectedOutput, encoded);
+
+            // Also check that encode first decodes percent-encoded values.
+            Assert.Equal(expectedOutput, PercentCodec.Encode(encoded, decodeFirst: true));
+        }
+    }
+}

--- a/test/NSign.Abstractions.UnitTests/Signatures/MessageContextTests.InputChecking.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/MessageContextTests.InputChecking.cs
@@ -81,12 +81,12 @@ namespace NSign.Signatures
             Assert.False(context.HasSignatureComponent(new HttpHeaderStructuredFieldComponent("y-missing-dict", bindRequest: true)));
 
             Assert.True(context.HasSignatureComponent(new QueryParamComponent("a")));
-            Assert.True(context.HasSignatureComponent(new QueryParamComponent("c")));
+            Assert.False(context.HasSignatureComponent(new QueryParamComponent("c")));
             Assert.True(context.HasSignatureComponent(new QueryParamComponent("e")));
             Assert.False(context.HasSignatureComponent(new QueryParamComponent("x")));
 
             Assert.True(context.HasSignatureComponent(new QueryParamComponent("a", bindRequest: true)));
-            Assert.True(context.HasSignatureComponent(new QueryParamComponent("c", bindRequest: true)));
+            Assert.False(context.HasSignatureComponent(new QueryParamComponent("c", bindRequest: true)));
             Assert.True(context.HasSignatureComponent(new QueryParamComponent("e", bindRequest: true)));
             Assert.False(context.HasSignatureComponent(new QueryParamComponent("x", bindRequest: true)));
 

--- a/test/NSign.Abstractions.UnitTests/Signatures/MessageContextTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/MessageContextTests.cs
@@ -303,7 +303,7 @@ namespace NSign.Signatures
         }
 
         [Theory]
-        [InlineData("first", true)]
+        [InlineData("first", false)]
         [InlineData("second", true)]
         [InlineData("third", true)]
         [InlineData("fourth", false)]

--- a/test/NSign.Abstractions.UnitTests/Signatures/QueryParamComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/QueryParamComponentTests.cs
@@ -30,10 +30,15 @@ namespace NSign.Signatures
             Assert.Equal("@query-param", queryParam.ComponentName);
         }
 
-        [Fact]
-        public void NameParameterIsNormalized()
+        [Theory]
+        [InlineData("a", "a")]
+        [InlineData("résumé", "résumé")]
+        [InlineData("r%C3%A9sum%C3%A9", "résumé")]
+        [InlineData("r%C3%A9sumé", "résumé")]
+        public void NameParameterIsNormalized(string inputName, string parameterName)
         {
-            Assert.Equal("myparam", queryParam.Name);
+            QueryParamComponent queryParam = new QueryParamComponent(inputName);
+            Assert.Equal(parameterName, queryParam.Name);
         }
 
         [Fact]

--- a/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
@@ -96,5 +96,38 @@ namespace NSign.Signatures
             ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new DerivedComponent("@signature-params")));
             Assert.Equal("Cannot add a '@signature-params' component to a SignatureParamsComponent.", ex.Message);
         }
+
+        [Fact]
+        public void AddComponentThrowsForDuplicateComponents()
+        {
+            InvalidOperationException ex;
+
+            signatureParams
+                .AddComponent(SignatureComponent.RequestBoundQuery)
+                .AddComponent(SignatureComponent.Query)
+                .AddComponent(new QueryParamComponent("abc", bindRequest: true))
+                .AddComponent(new QueryParamComponent("abcdef", bindRequest: false))
+                ;
+
+            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(SignatureComponent.RequestBoundQuery));
+            Assert.Equal(
+                "The component '@query;req' has already been added. Adding the same component twice is not allowed", 
+                ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(SignatureComponent.Query));
+            Assert.Equal(
+                "The component '@query' has already been added. Adding the same component twice is not allowed",
+                ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new QueryParamComponent("abc", bindRequest: true)));
+            Assert.Equal(
+                "The component '@query-param;name=abc' has already been added. Adding the same component twice is not allowed",
+                ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new QueryParamComponent("abcdef", bindRequest: false)));
+            Assert.Equal(
+                "The component '@query-param;name=abcdef' has already been added. Adding the same component twice is not allowed",
+                ex.Message);
+        }
     }
 }

--- a/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
@@ -54,7 +54,7 @@ namespace NSign.Signatures
         {
             signatureParams
                 .AddComponent(SignatureComponent.Authority)
-                .AddComponent(SignatureComponent.Digest)
+                .AddComponent(SignatureComponent.ContentDigest)
                 .AddComponent(SignatureComponent.Path)
                 .WithAlgorithm(SignatureAlgorithm.HmacSha256)
                 .WithCreatedNow()
@@ -65,7 +65,7 @@ namespace NSign.Signatures
 
             Assert.Collection(signatureParams.Components,
               (c) => Assert.Equal(SignatureComponent.Authority, c),
-              (c) => Assert.Equal(SignatureComponent.Digest, c),
+              (c) => Assert.Equal(SignatureComponent.ContentDigest, c),
               (c) => Assert.Equal(SignatureComponent.Path, c));
 
             Assert.Equal("hmac-sha256", signatureParams.Algorithm);

--- a/test/NSign.Abstractions.UnitTests/packages.lock.json
+++ b/test/NSign.Abstractions.UnitTests/packages.lock.json
@@ -359,8 +359,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -1652,8 +1652,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/ContentDigestVerificationMiddlewareTests.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/ContentDigestVerificationMiddlewareTests.cs
@@ -6,24 +6,24 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using static NSign.AspNetCore.DigestVerificationOptions;
+using static NSign.AspNetCore.ContentDigestVerificationOptions;
 
 namespace NSign.AspNetCore
 {
-    public sealed class DigestVerificationMiddlewareTests
+    public sealed class ContentDigestVerificationMiddlewareTests
     {
         private readonly DefaultHttpContext httpContext = new DefaultHttpContext();
-        private readonly DigestVerificationOptions options;
-        private readonly DigestVerificationMiddleware middleware;
+        private readonly ContentDigestVerificationOptions options;
+        private readonly ContentDigestVerificationMiddleware middleware;
         private long numCallsToNext;
 
-        public DigestVerificationMiddlewareTests()
+        public ContentDigestVerificationMiddlewareTests()
         {
-            options = new DigestVerificationOptions();
+            options = new ContentDigestVerificationOptions();
 
-            middleware = new DigestVerificationMiddleware(
-                new NullLogger<DigestVerificationMiddleware>(),
-                new OptionsWrapper<DigestVerificationOptions>(options));
+            middleware = new ContentDigestVerificationMiddleware(
+                new NullLogger<ContentDigestVerificationMiddleware>(),
+                new OptionsWrapper<ContentDigestVerificationOptions>(options));
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace NSign.AspNetCore
 
             using Stream bodyStream = MakeStream(body);
             httpContext.Request.Body = bodyStream;
-            httpContext.Request.Headers.Add("Digest", headers);
+            httpContext.Request.Headers.Add("Content-Digest", headers);
 
             await middleware.InvokeAsync(httpContext, CountingMiddleware);
 
@@ -123,7 +123,7 @@ namespace NSign.AspNetCore
         {
             options.VerificationFailuresResponseStatus = 555;
 
-            httpContext.Request.Headers.Add("Digest", headers);
+            httpContext.Request.Headers.Add("Content-Digest", headers);
 
             await middleware.InvokeAsync(httpContext, CountingMiddleware);
 
@@ -139,7 +139,7 @@ namespace NSign.AspNetCore
             options.VerificationFailuresResponseStatus = 999;
             options.Behavior = behavior;
 
-            httpContext.Request.Headers.Add("Digest", headers);
+            httpContext.Request.Headers.Add("Content-Digest", headers);
 
             await middleware.InvokeAsync(httpContext, CountingMiddleware);
 
@@ -164,7 +164,7 @@ namespace NSign.AspNetCore
 
         //    using Stream bodyStream = MakeStream(body);
         //    httpContext.Request.Body = bodyStream;
-        //    httpContext.Request.Headers.Add("Digest", headers);
+        //    httpContext.Request.Headers.Add("Content-Digest", headers);
 
         //    await middleware.InvokeAsync(httpContext, CountingMiddleware);
 

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/RequestMessageContextTests.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/RequestMessageContextTests.cs
@@ -279,11 +279,13 @@ namespace NSign.AspNetCore
         [InlineData("A", true)]
         [InlineData("c", true)]
         [InlineData("e", true)]
+        [InlineData("b", false)]
+        [InlineData("B", false)]
         public void HasQueryParamWorks(string name, bool expectedResult)
         {
-            httpContext.Request.QueryString = new QueryString("?a=b&a=bb&c=d&e=");
+            httpContext.Request.QueryString = new QueryString("?a=b&b=bb&b=b&c=d&e=");
 
-            Assert.Equal(expectedResult, context.HasQueryParam(name));
+            Assert.Equal(expectedResult, context.HasExactlyOneQueryParamValue(name));
         }
 
         [Fact]

--- a/test/NSign.AspNetCore.UnitTests/packages.lock.json
+++ b/test/NSign.AspNetCore.UnitTests/packages.lock.json
@@ -361,8 +361,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -1298,7 +1298,7 @@
       "nsign.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )"
         }
       }
@@ -1663,8 +1663,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -2600,7 +2600,7 @@
       "nsign.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )"
         }
       }

--- a/test/NSign.Client.UnitTests/Client/HttpRequestMessageContextTests.cs
+++ b/test/NSign.Client.UnitTests/Client/HttpRequestMessageContextTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NSign.Http;
 using NSign.Signatures;
@@ -264,11 +264,13 @@ namespace NSign.Client
         [InlineData("c", true)]
         [InlineData("e", true)]
         [InlineData("E", true)]
+        [InlineData("b", false)]
+        [InlineData("B", false)]
         public void HasQueryParamWorks(string name, bool expectedResult)
         {
-            request.RequestUri = new Uri("http://localhost:8080/?a=b&a=bb&c=d&A=B&e=");
+            request.RequestUri = new Uri("http://localhost:8080/?a=b&b=bb&b=b&c=d&D=B&e=");
 
-            Assert.Equal(expectedResult, context.HasQueryParam(name));
+            Assert.Equal(expectedResult, context.HasExactlyOneQueryParamValue(name));
         }
 
         [Fact]

--- a/test/NSign.Client.UnitTests/packages.lock.json
+++ b/test/NSign.Client.UnitTests/packages.lock.json
@@ -31,10 +31,10 @@
       "System.Net.Http.Json": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.0.0",
-        "contentHash": "GbIV4y344kGOKjshAKCIDCMUTTW/hyUC42wV0Y5SXEdIbaKBIHBUxZ2MOe4/ZiV2svUAGfQ0c8LGtUExpOI8tg==",
+        "resolved": "6.0.1",
+        "contentHash": "5wwf+HrtBkiEAFJbPknDwOXNp12BbiJ3268RILCl8EydO/ffXVxlRbOJi+R2lrn0cBpc4OrFJc7fW4/pGGU6Gw==",
         "dependencies": {
-          "System.Text.Json": "6.0.0"
+          "System.Text.Json": "6.0.7"
         }
       },
       "xunit": {
@@ -400,8 +400,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -1190,8 +1190,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "resolved": "6.0.7",
+        "contentHash": "/Tf/9XjprpHolbcDOrxsKVYy/mUG/FS7aGd9YUgBVEiHeQH4kAE0T1sMbde7q6B5xcrNUsJ5iW7D1RvHudQNqA==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"
@@ -1358,7 +1358,7 @@
           "Microsoft.Extensions.Http": "[6.0.*, )",
           "Microsoft.Extensions.Logging.Abstractions": "[6.0.*, )",
           "Microsoft.Extensions.Options": "[6.0.*, )",
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )",
           "System.Collections.Immutable": "[6.0.*, )",
           "System.IO.Pipelines": "[6.*, )"
@@ -1395,10 +1395,10 @@
       "System.Net.Http.Json": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.0.0",
-        "contentHash": "GbIV4y344kGOKjshAKCIDCMUTTW/hyUC42wV0Y5SXEdIbaKBIHBUxZ2MOe4/ZiV2svUAGfQ0c8LGtUExpOI8tg==",
+        "resolved": "6.0.1",
+        "contentHash": "5wwf+HrtBkiEAFJbPknDwOXNp12BbiJ3268RILCl8EydO/ffXVxlRbOJi+R2lrn0cBpc4OrFJc7fW4/pGGU6Gw==",
         "dependencies": {
-          "System.Text.Json": "6.0.0"
+          "System.Text.Json": "6.0.7"
         }
       },
       "xunit": {
@@ -1764,8 +1764,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -2554,8 +2554,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "resolved": "6.0.7",
+        "contentHash": "/Tf/9XjprpHolbcDOrxsKVYy/mUG/FS7aGd9YUgBVEiHeQH4kAE0T1sMbde7q6B5xcrNUsJ5iW7D1RvHudQNqA==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"
@@ -2722,7 +2722,7 @@
           "Microsoft.Extensions.Http": "[6.0.*, )",
           "Microsoft.Extensions.Logging.Abstractions": "[6.0.*, )",
           "Microsoft.Extensions.Options": "[6.0.*, )",
-          "NSign.Abstractions": "[0.15.1, )",
+          "NSign.Abstractions": "[0.17.0, )",
           "StructuredFieldValues": "[0.*, )",
           "System.Collections.Immutable": "[6.0.*, )",
           "System.IO.Pipelines": "[6.*, )"

--- a/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
@@ -105,6 +105,83 @@ namespace NSign.Providers
             Assert.Equal(VerificationResult.SuccessfullyVerified, result);
         }
 
+        [Fact]
+        public async Task Draft17_2_4_Example1_Verify()
+        {
+            ECDsaP256Sha256SignatureProvider provider = Make(false, "test-key-ecc-p256", "test-key-ecc-p256");
+
+            string input =
+                "\"@status\": 503\n" +
+                "\"content-digest\": sha-512=:0Y6iCBzGg5rZtoXS95Ijz03mslf6KAMCloESHObfwnHJDbkkWWQz6PhhU9kxsTbARtY2PTBOzq24uJFpHsMuAg==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"@authority\";req: origin.host.internal.example\n" +
+                "\"@method\";req: POST\n" +
+                "\"@path\";req: /foo\n" +
+                "\"content-digest\";req: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"@signature-params\": (\"@status\" \"content-digest\" \"content-type\" \"@authority\";req \"@method\";req \"@path\";req \"content-digest\";req);created=1618884479;keyid=\"test-key-ecc-p256\"";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"@status\" \"content-digest\" \"content-type\" \"@authority\";req \"@method\";req \"@path\";req \"content-digest\";req);created=1618884479;keyid=\"test-key-ecc-p256\"");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String("9MG6AOgykOZTc/h2rnDc/g8L+/aXgdkV4hNDvpCxfbVrmLevWPfyvEC/8jBh+3XnVwBqqcJyhUXoFgWv1SMI7A=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
+        [Fact]
+        public async Task Draft17_2_4_Example2_Verify()
+        {
+            ECDsaP256Sha256SignatureProvider provider = Make(false, "test-key-ecc-p256", "test-key-ecc-p256");
+
+            string input =
+                "\"@status\": 503\n" +
+                "\"content-digest\": sha-512=:0Y6iCBzGg5rZtoXS95Ijz03mslf6KAMCloESHObfwnHJDbkkWWQz6PhhU9kxsTbARtY2PTBOzq24uJFpHsMuAg==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"@authority\";req: origin.host.internal.example\n" +
+                "\"@method\";req: POST\n" +
+                "\"@path\";req: /foo\n" +
+                "\"@query\";req: ?param=Value&Pet=dog\n" +
+                "\"content-digest\";req: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"content-type\";req: application/json\n" +
+                "\"content-length\";req: 18\n" +
+                "\"@signature-params\": (\"@status\" \"content-digest\" \"content-type\" \"@authority\";req \"@method\";req \"@path\";req \"@query\";req \"content-digest\";req \"content-type\";req \"content-length\";req);created=1618884479;keyid=\"test-key-ecc-p256\"";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"@status\" \"content-digest\" \"content-type\" \"@authority\";req \"@method\";req \"@path\";req \"@query\";req \"content-digest\";req \"content-type\";req \"content-length\";req);created=1618884479;keyid=\"test-key-ecc-p256\"");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String("zU7zd1MN56WapeNxfVNleCx5rFxBhBcZngnX4d+MurOk3tNu3rFfTFnwhglZH8qNBoygvhVMfQq9wIvLqyVNog=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
+        [Fact]
+        public async Task Draft17_4_3_Example2_Verify()
+        {
+            ECDsaP256Sha256SignatureProvider provider = Make(false, "test-key-ecc-p256", "test-key-ecc-p256");
+
+            string input =
+                "\"@method\": POST\n" +
+                "\"@authority\": example.com\n" +
+                "\"@path\": /foo\n" +
+                "\"content-digest\": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"content-length\": 18\n" +
+                "\"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\");created=1618884475;keyid=\"test-key-ecc-p256\"";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\");created=1618884475;keyid=\"test-key-ecc-p256\"");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String("X5spyd6CFnAG5QnDyHfqoSNICd+BUP4LYMz2Q0JXlb//4Ijpzp+kve2w4NIyqeAuM7jTDX+sNalzA8ESSaHD3A=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
         #endregion
 
         [Theory]

--- a/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
@@ -113,6 +113,53 @@ namespace NSign.Providers
             Assert.Equal(VerificationResult.SuccessfullyVerified, result);
         }
 
+        [Fact]
+        public async Task Draft17_4_3_Example1_Sign()
+        {
+            RsaPkcs15Sha256SignatureProvider provider = Make(true, "test-key-rsa", "test-key-rsa");
+
+            string input =
+                "\"@method\": POST\n" +
+                "\"@authority\": origin.host.internal.example\n" +
+                "\"@path\": /foo\n" +
+                "\"content-digest\": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"content-length\": 18\n" +
+                "\"forwarded\": for=192.0.2.123;host=example.com;proto=https\n" +
+                "\"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540";
+
+            ReadOnlyMemory<byte> signature = await provider.SignAsync(Encoding.ASCII.GetBytes(input), default);
+            string sigBase64 = Convert.ToBase64String(signature.Span);
+            Assert.Equal(
+                "S6ZzPXSdAMOPjN/6KXfXWNO/f7V6cHm7BXYUh3YD/fRad4BCaRZxP+JH+8XY1I6+8Cy+CM5g92iHgxtRPz+MjniOaYmdkDcnL9cCpXJleXsOckpURl49GwiyUpZ10KHgOEe11sx3G2gxI8S0jnxQB+Pu68U9vVcasqOWAEObtNKKZd8tSFu7LB5YAv0RAGhB8tmpv7sFnIm9y+7X5kXQfi8NMaZaA8i2ZHwpBdg7a6CMfwnnrtflzvZdXAsD3LH2TwevU+/PBPv0B6NMNk93wUs/vfJvye+YuI87HU38lZHowtznbLVdp770I6VHR6WfgS9ddzirrswsE1w5o0LV/g==",
+                sigBase64);
+        }
+
+        [Fact]
+        public async Task Draft17_4_3_Example1_Verify()
+        {
+            RsaPkcs15Sha256SignatureProvider provider = Make(false, "test-key-rsa", "test-key-rsa");
+
+            string input =
+                "\"@method\": POST\n" +
+                "\"@authority\": origin.host.internal.example\n" +
+                "\"@path\": /foo\n" +
+                "\"content-digest\": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n" +
+                "\"content-type\": application/json\n" +
+                "\"content-length\": 18\n" +
+                "\"forwarded\": for=192.0.2.123;host=example.com;proto=https\n" +
+                "\"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540";
+            SignatureParamsComponent sigParams = new SignatureParamsComponent(
+                "(\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\" \"forwarded\");created=1618884480;keyid=\"test-key-rsa\";alg=\"rsa-v1_5-sha256\";expires=1618884540");
+
+            VerificationResult result = await provider.VerifyAsync(
+                sigParams,
+                Encoding.ASCII.GetBytes(input),
+                Convert.FromBase64String("S6ZzPXSdAMOPjN/6KXfXWNO/f7V6cHm7BXYUh3YD/fRad4BCaRZxP+JH+8XY1I6+8Cy+CM5g92iHgxtRPz+MjniOaYmdkDcnL9cCpXJleXsOckpURl49GwiyUpZ10KHgOEe11sx3G2gxI8S0jnxQB+Pu68U9vVcasqOWAEObtNKKZd8tSFu7LB5YAv0RAGhB8tmpv7sFnIm9y+7X5kXQfi8NMaZaA8i2ZHwpBdg7a6CMfwnnrtflzvZdXAsD3LH2TwevU+/PBPv0B6NMNk93wUs/vfJvye+YuI87HU38lZHowtznbLVdp770I6VHR6WfgS9ddzirrswsE1w5o0LV/g=="),
+                default);
+            Assert.Equal(VerificationResult.SuccessfullyVerified, result);
+        }
+
         #endregion
 
         [Theory]

--- a/test/NSign.SignatureProviders.UnitTests/packages.lock.json
+++ b/test/NSign.SignatureProviders.UnitTests/packages.lock.json
@@ -359,8 +359,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -1296,7 +1296,7 @@
       "nsign.signatureproviders": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )"
+          "NSign.Abstractions": "[0.17.0, )"
         }
       }
     },
@@ -1658,8 +1658,8 @@
       },
       "StructuredFieldValues": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "Ze846JAvsWDreOvoIBFY247Sa6W+gUzf//t6pNg8uEBmec6HTzhPvFV2E1LViYq/jCxJ1qKPwgaezfNLKb19lA==",
+        "resolved": "0.5.3",
+        "contentHash": "G0uqNU82bf3dloMYkzHyThT35D64SpDK8pe2/xO1TDU39R2t1PTNuzIv1HT7OgdVOWDyZ6kKxS5H0hVVcMhvPw==",
         "dependencies": {
           "System.Memory": "4.5.5"
         }
@@ -2595,7 +2595,7 @@
       "nsign.signatureproviders": {
         "type": "Project",
         "dependencies": {
-          "NSign.Abstractions": "[0.15.1, )"
+          "NSign.Abstractions": "[0.17.0, )"
         }
       }
     }


### PR DESCRIPTION
- Disallow adding the same component multiple times to a signature.
- Use `content-digest` instead of just `digest`.
- No longer allow query parameters having multiple values be used for signatures.
- Percent-encode the name and value for `@query-param` components.
- Fix bug in signature input parser.
- Update Nuget packages.
- Bump version.