### PR TITLE
Enable signatures for historical drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin/
 obj/
 TestResults/
 Coverage/
+.idea/
+*.DotSettings.user

--- a/src/NSign.Abstractions/Signatures/ISignatureComponentBuildVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/ISignatureComponentBuildVisitor.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Contract for a SignatureComponent visitor that should build the signature input document.
     /// </summary>
-    public interface ISignatureComponentInputVisitor : ISignatureComponentVisitor
+    public interface ISignatureComponentBuildVisitor : ISignatureComponentVisitor
     {
         /// <summary>
         /// The signature input as built by the visitor.

--- a/src/NSign.Abstractions/Signatures/ISignatureComponentCheckVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/ISignatureComponentCheckVisitor.cs
@@ -1,0 +1,13 @@
+﻿namespace NSign.Signatures
+{
+    /// <summary>
+    /// Contract for a SignatureComponent visitor that should validate the signature.
+    /// </summary>
+    public interface ISignatureComponentCheckVisitor : ISignatureComponentVisitor
+    {
+        /// <summary>
+        /// Gets or sets a flag which indicates whether or not all the tested components were found.
+        /// </summary>
+        public bool Found { get; }
+    }
+}

--- a/src/NSign.Abstractions/Signatures/ISignatureComponentInputVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/ISignatureComponentInputVisitor.cs
@@ -1,0 +1,18 @@
+﻿namespace NSign.Signatures
+{
+    /// <summary>
+    /// Contract for a SignatureComponent visitor that should build the signature input document.
+    /// </summary>
+    public interface ISignatureComponentInputVisitor : ISignatureComponentVisitor
+    {
+        /// <summary>
+        /// The signature input as built by the visitor.
+        /// </summary>
+        string SignatureInput { get; }
+        
+        /// <summary>
+        /// The value for the '@signature-params' component, as built by the visitor.
+        /// </summary>
+        string? SignatureParamsValue { get; }
+    }
+}

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
@@ -12,7 +12,7 @@ namespace NSign.Signatures
         /// <summary>
         /// Implements the VisitorBase class to assist with building strings for signature input.
         /// </summary>
-        private sealed class InputBuildingVisitor : VisitorBase, ISignatureComponentInputVisitor
+        private sealed class InputBuildingVisitor : VisitorBase, ISignatureComponentBuildVisitor
         {
             /// <summary>
             /// The parameter to use to indicate that a component is bound to the request.

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
@@ -47,14 +47,10 @@ namespace NSign.Signatures
             /// </param>
             public InputBuildingVisitor(MessageContext context) : base(context) { }
 
-            /// <summary>
-            /// The signature input as built by the visitor.
-            /// </summary>
+            /// <inheritdoc/>
             public string SignatureInput => signatureInput.ToString();
 
-            /// <summary>
-            /// The value for the '@signature-params' component, as built by the visitor.
-            /// </summary>
+            /// <inheritdoc/>
             public string? SignatureParamsValue { get; private set; }
 
             /// <inheritdoc/>

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputBuildingVisitor.cs
@@ -12,7 +12,7 @@ namespace NSign.Signatures
         /// <summary>
         /// Implements the VisitorBase class to assist with building strings for signature input.
         /// </summary>
-        private sealed class InputBuildingVisitor : VisitorBase
+        private sealed class InputBuildingVisitor : VisitorBase, ISignatureComponentInputVisitor
         {
             /// <summary>
             /// The parameter to use to indicate that a component is bound to the request.

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
@@ -19,9 +19,7 @@ namespace NSign.Signatures
             /// </param>
             public InputCheckingVisitor(MessageContext context) : base(context) { }
 
-            /// <summary>
-            /// Gets or sets a flag which indicates whether or not all the tested components were found.
-            /// </summary>
+            /// <inheritdoc/>
             public bool Found { get; private set; } = true;
 
             /// <inheritdoc/>

--- a/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.InputCheckingVisitor.cs
@@ -9,7 +9,7 @@ namespace NSign.Signatures
         /// <summary>
         /// Implements the InputVisitorBase class to assist with checking for existence of signature components.
         /// </summary>
-        private sealed class InputCheckingVisitor : VisitorBase
+        private sealed class InputCheckingVisitor : VisitorBase, ISignatureComponentCheckVisitor
         {
             /// <summary>
             /// Initializes a new instance of InputCheckingVisitor.

--- a/src/NSign.Abstractions/Signatures/MessageContext.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.cs
@@ -83,14 +83,16 @@ namespace NSign.Signatures
         /// <param name="component">
         /// A <see cref="SignatureComponent"/> object that describes the component to check.
         /// </param>
+        /// <param name="visitor">Optional. A customized input checking visitor, to support historical drafts of the
+        /// spec.</param>
         /// <returns>
         /// True if the component is available (and can be used in signatures), false otherwise.
         /// </returns>
-        public bool HasSignatureComponent(SignatureComponent component)
+        public bool HasSignatureComponent(SignatureComponent component, ISignatureComponentCheckVisitor? visitor = null)
         {
             EnsureComponentIsAllowed(component);
-
-            InputCheckingVisitor visitor = new InputCheckingVisitor(this);
+            
+            visitor ??= new InputCheckingVisitor(this);
 
             component.Accept(visitor);
 
@@ -108,14 +110,17 @@ namespace NSign.Signatures
         /// A string that receives the representation of the '@signature-params' component for the given
         /// <paramref name="signatureParams"/> when the method returns.
         /// </param>
+        /// <param name="visitor">Optional. A customized input building visitor, to support historical drafts of the
+        /// spec.</param>
         /// <returns>
         /// A <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/> representing the signature input.
         /// </returns>
         public ReadOnlyMemory<byte> GetSignatureInput(
             SignatureParamsComponent signatureParams,
-            out string signatureParamsValue)
+            out string signatureParamsValue,
+            ISignatureComponentInputVisitor? visitor = null)
         {
-            InputBuildingVisitor visitor = new InputBuildingVisitor(this);
+            visitor ??= new InputBuildingVisitor(this);
 
             signatureParams.Accept(visitor);
             signatureParamsValue = visitor.SignatureParamsValue!;

--- a/src/NSign.Abstractions/Signatures/MessageContext.cs
+++ b/src/NSign.Abstractions/Signatures/MessageContext.cs
@@ -118,7 +118,7 @@ namespace NSign.Signatures
         public ReadOnlyMemory<byte> GetSignatureInput(
             SignatureParamsComponent signatureParams,
             out string signatureParamsValue,
-            ISignatureComponentInputVisitor? visitor = null)
+            ISignatureComponentBuildVisitor? visitor = null)
         {
             visitor ??= new InputBuildingVisitor(this);
 


### PR DESCRIPTION
This change allows an `IMessageSigner` or `IMessageVerifier` to specify custom `ISignatureComponentVisitor`s. This is useful to interoperate with services that target older drafts of the Http Signatures spec. Unfortunately, I think this is still kind of difficult to accomplish, because it would require replacing the entire default message signer and verifier with nearly identical custom implementations through DI.

Alternatively, if the default signer and verifier can be unsealed and refactored a little, then they can be inherited and changing the visitor they use can be much less demanding. But that's a more substantial change to NSign, and I wasn't sure you'd appreciate that.

Do you have any thoughts?