### PR TITLE
Refactor signature provider methods for async support

### DIFF
--- a/src/NSign.Abstractions/ISigner.cs
+++ b/src/NSign.Abstractions/ISigner.cs
@@ -17,7 +17,7 @@ namespace NSign
         /// <param name="signatureParams">
         /// The SignatureParamsComponent object holding the signature parameters to update, if necessary.
         /// </param>
-        void UpdateSignatureParams(SignatureParamsComponent signatureParams);
+        Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken);
 
         /// <summary>
         /// Signs the given input asynchronously.
@@ -32,6 +32,6 @@ namespace NSign
         /// A Task which results in a <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/> representing the signature
         /// when it completes.
         /// </returns>
-        Task<ReadOnlyMemory<byte>> SignAsync(ReadOnlyMemory<byte> input, CancellationToken cancellationToken);
+        Task<ReadOnlyMemory<byte>> SignAsync(string? keyId, ReadOnlyMemory<byte> input, CancellationToken cancellationToken);
     }
 }

--- a/src/NSign.Abstractions/Providers/SignatureProvider.cs
+++ b/src/NSign.Abstractions/Providers/SignatureProvider.cs
@@ -29,9 +29,26 @@ namespace NSign.Providers
         public string? KeyId { get; }
 
         /// <inheritdoc/>
-        public virtual void UpdateSignatureParams(SignatureParamsComponent signatureParams)
+        public virtual Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             signatureParams.KeyId = KeyId;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<ReadOnlyMemory<byte>> SignAsync(
+            string? keyId,
+            ReadOnlyMemory<byte> input,
+            CancellationToken cancellationToken)
+        {
+            if (this.KeyId != keyId)
+            {
+                throw new InvalidOperationException("The specified keyId does not match the keyId of this provider.");
+            }
+
+            return SignAsync(input, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/NSign.Abstractions/Signatures/DefaultMessageSigner.cs
+++ b/src/NSign.Abstractions/Signatures/DefaultMessageSigner.cs
@@ -66,10 +66,11 @@ namespace NSign.Signatures
 
             if (options.UseUpdateSignatureParams)
             {
-                signer.UpdateSignatureParams(inputSpec.SignatureParameters);
+                await signer.UpdateSignatureParamsAsync(inputSpec.SignatureParameters, context, context.Aborted);
             }
 
             ReadOnlyMemory<byte> signature = await signer.SignAsync(
+                inputSpec.SignatureParameters.KeyId,
                 context.GetSignatureInput(inputSpec.SignatureParameters, out string sigInput),
                 context.Aborted);
 

--- a/src/NSign.BouncyCastle/Providers/EdDsaEdwards25519SignatureProvider.cs
+++ b/src/NSign.BouncyCastle/Providers/EdDsaEdwards25519SignatureProvider.cs
@@ -97,9 +97,10 @@ namespace NSign.BouncyCastle.Providers
         }
 
         /// <inheritdoc/>
-        public override void UpdateSignatureParams(SignatureParamsComponent signatureParams)
+        public override async Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken)
         {
-            base.UpdateSignatureParams(signatureParams);
+            await base.UpdateSignatureParamsAsync(signatureParams, messageContext, cancellationToken);
+
             signatureParams.Algorithm = AlgorithmName;
         }
 

--- a/src/NSign.SignatureProviders/Providers/ECDsaSignatureProvider.cs
+++ b/src/NSign.SignatureProviders/Providers/ECDsaSignatureProvider.cs
@@ -154,9 +154,9 @@ namespace NSign.Providers
         }
 
         /// <inheritdoc/>
-        public override void UpdateSignatureParams(SignatureParamsComponent signatureParams)
+        public override async Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken)
         {
-            base.UpdateSignatureParams(signatureParams);
+            await base.UpdateSignatureParamsAsync(signatureParams, messageContext, cancellationToken);
 
             if (!String.IsNullOrWhiteSpace(algorithmName))
             {

--- a/src/NSign.SignatureProviders/Providers/HmacSha256SignatureProvider.cs
+++ b/src/NSign.SignatureProviders/Providers/HmacSha256SignatureProvider.cs
@@ -1,5 +1,7 @@
 ﻿using NSign.Signatures;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NSign.Providers
 {
@@ -38,9 +40,10 @@ namespace NSign.Providers
         }
 
         /// <inheritdoc/>
-        public override void UpdateSignatureParams(SignatureParamsComponent signatureParams)
+        public override async Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken)
         {
-            base.UpdateSignatureParams(signatureParams);
+            await base.UpdateSignatureParamsAsync(signatureParams, messageContext, cancellationToken);
+
             signatureParams.Algorithm = Constants.SignatureAlgorithms.HmacSha256;
         }
 

--- a/src/NSign.SignatureProviders/Providers/RsaSignatureProvider.cs
+++ b/src/NSign.SignatureProviders/Providers/RsaSignatureProvider.cs
@@ -158,9 +158,9 @@ namespace NSign.Providers
         }
 
         /// <inheritdoc/>
-        public override void UpdateSignatureParams(SignatureParamsComponent signatureParams)
+        public override async Task UpdateSignatureParamsAsync(SignatureParamsComponent signatureParams, MessageContext messageContext, CancellationToken cancellationToken)
         {
-            base.UpdateSignatureParams(signatureParams);
+            await base.UpdateSignatureParamsAsync(signatureParams, messageContext, cancellationToken);
 
             if (!String.IsNullOrWhiteSpace(algorithmName))
             {

--- a/test/NSign.Abstractions.UnitTests/Providers/SignatureProviderTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Providers/SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +10,14 @@ namespace NSign.Providers
 {
     public sealed class SignatureProviderTests
     {
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -23,13 +33,13 @@ namespace NSign.Providers
         [InlineData("")]
         [InlineData("MyKey")]
         [InlineData("AnotherKey")]
-        public void UpdateSignatureParamsSetsKeyIdParameter(string? keyId)
+        public async Task UpdateSignatureParamsSetsKeyIdParameter(string? keyId)
         {
             SignatureProvider provider = new TestProvider(keyId);
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.KeyId);
-            provider.UpdateSignatureParams(signatureParams);
+            await provider.UpdateSignatureParamsAsync(signatureParams, messageContext, CancellationToken.None);
             Assert.Equal(keyId, signatureParams.KeyId);
         }
 

--- a/test/NSign.BouncyCastle.UnitTests/NSign.BouncyCastle.UnitTests.csproj
+++ b/test/NSign.BouncyCastle.UnitTests/NSign.BouncyCastle.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Moq" Version="4.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/NSign.BouncyCastle.UnitTests/Providers/EdDsaEdwards25519SignatureProviderTests.cs
+++ b/test/NSign.BouncyCastle.UnitTests/Providers/EdDsaEdwards25519SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.OpenSsl;
 using System;
@@ -16,6 +18,13 @@ namespace NSign.BouncyCastle.Providers
 
         private readonly Ed25519PrivateKeyParameters privateKeyFromStandard = GetPrivateKeyFromStandard();
         private readonly Ed25519PublicKeyParameters publicKeyFromStandard = GetPublicKeyFromStandard();
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public EdDsaEdwards25519SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         [Fact]
         public void CtorValidatesInput()
@@ -101,7 +110,7 @@ namespace NSign.BouncyCastle.Providers
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             (_, Ed25519PublicKeyParameters publicKey) =
                 GetKeys("ed25519.nsign.test.local");
@@ -109,7 +118,7 @@ namespace NSign.BouncyCastle.Providers
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            signingProvider.UpdateSignatureParams(signatureParams);
+            await signingProvider.UpdateSignatureParamsAsync(signatureParams, this.messageContext, CancellationToken.None);
             Assert.Equal("ed25519", signatureParams.Algorithm);
         }
 

--- a/test/NSign.BouncyCastle.UnitTests/Providers/TestMessageContext.cs
+++ b/test/NSign.BouncyCastle.UnitTests/Providers/TestMessageContext.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Extensions.Logging;
+using NSign.Http;
+using NSign.Signatures;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace NSign.BouncyCastle.Providers
+{
+    internal sealed class TestMessageContext : MessageContext
+    {
+        public TestMessageContext(ILogger logger) : base(logger, new HttpFieldOptions())
+        { }
+
+        internal bool HasResponseValue { get; set; }
+
+        internal CancellationToken AbortedValue { get; set; }
+
+        internal Action<string, string>? OnAddHeader { get; set; }
+
+        internal Func<DerivedComponent, string?>? OnGetDerivedComponentValue { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetHeaderValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetTrailerValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetRequestHeaderValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetRequestTrailerValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetQueryParamValues { get; set; }
+
+        public override bool HasResponse => HasResponseValue;
+
+        public override CancellationToken Aborted => AbortedValue;
+
+        public override void AddHeader(string headerName, string value)
+        {
+            OnAddHeader!(headerName, value);
+        }
+
+        public override string? GetDerivedComponentValue(DerivedComponent component)
+        {
+            return OnGetDerivedComponentValue!(component);
+        }
+
+        public override IEnumerable<string> GetHeaderValues(string headerName)
+        {
+            return OnGetHeaderValues!(headerName);
+        }
+
+        public override IEnumerable<string> GetTrailerValues(string fieldName)
+        {
+            return OnGetTrailerValues!(fieldName);
+        }
+
+        public override IEnumerable<string> GetQueryParamValues(string paramName)
+        {
+            return OnGetQueryParamValues!(paramName);
+        }
+
+        public override IEnumerable<string> GetRequestHeaderValues(string headerName)
+        {
+            return OnGetRequestHeaderValues!(headerName);
+        }
+
+        public override IEnumerable<string> GetRequestTrailerValues(string fieldName)
+        {
+            return OnGetRequestTrailerValues!(fieldName);
+        }
+    }
+}

--- a/test/NSign.BouncyCastle.UnitTests/packages.lock.json
+++ b/test/NSign.BouncyCastle.UnitTests/packages.lock.json
@@ -18,6 +18,15 @@
           "Microsoft.TestPlatform.TestHost": "17.13.0"
         }
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.20.72",
+        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.*, )",
@@ -39,6 +48,14 @@
         "type": "Transitive",
         "resolved": "2.5.1",
         "contentHash": "zy8TMeTP+1FH2NrLaNZtdRbBdq7u5MI+NFZQOBSM69u5RFkciinwzV2eveY6Kjf5MzgsYvvl6kTStsj3JrXqkg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -112,6 +129,11 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -193,6 +215,15 @@
           "Microsoft.TestPlatform.TestHost": "17.13.0"
         }
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.20.72",
+        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.*, )",
@@ -214,6 +245,14 @@
         "type": "Transitive",
         "resolved": "2.5.1",
         "contentHash": "zy8TMeTP+1FH2NrLaNZtdRbBdq7u5MI+NFZQOBSM69u5RFkciinwzV2eveY6Kjf5MzgsYvvl6kTStsj3JrXqkg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -287,6 +326,11 @@
         "type": "Transitive",
         "resolved": "9.0.3",
         "contentHash": "CfYi30Pbpw9aGpXVLcoGt+yM0egrE8M1DUOOwdAWOAQ2QZkXkSgjonqZYvtKdxUF1XJaLCp0OdTXueeAeUHSlQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",

--- a/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP256Sha256SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -11,6 +13,13 @@ namespace NSign.Providers
     public sealed class ECDsaP256Sha256SignatureProviderTests
     {
         private readonly Random rng = new Random();
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public ECDsaP256Sha256SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         #region From standard
 
@@ -310,13 +319,13 @@ namespace NSign.Providers
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             ECDsaP256Sha256SignatureProvider signingProvider = Make(true);
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            signingProvider.UpdateSignatureParams(signatureParams);
+            await signingProvider.UpdateSignatureParamsAsync(signatureParams, this.messageContext, CancellationToken.None);
             Assert.Equal("ecdsa-p256-sha256", signatureParams.Algorithm);
         }
 

--- a/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP382Sha384SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/ECDsaP382Sha384SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -10,6 +12,13 @@ namespace NSign.Providers
     public sealed class ECDsaP382Sha384SignatureProviderTests
     {
         private readonly Random rng = new Random();
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public ECDsaP382Sha384SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         [Theory]
         [InlineData("ecdsa-p192-nsign.test.local", "P192")]
@@ -84,13 +93,13 @@ namespace NSign.Providers
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             ECDsaP382Sha384SignatureProvider signingProvider = Make(true);
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            signingProvider.UpdateSignatureParams(signatureParams);
+            await signingProvider.UpdateSignatureParamsAsync(signatureParams, this.messageContext, CancellationToken.None);
             Assert.Equal("ecdsa-p384-sha384", signatureParams.Algorithm);
         }
 

--- a/test/NSign.SignatureProviders.UnitTests/Providers/HmacSha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/HmacSha256SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Text;
 using System.Threading;
@@ -13,6 +15,13 @@ namespace NSign.Providers
         private static readonly byte[] defaultKey = Encoding.ASCII.GetBytes("mykey");
         private static readonly byte[] sharedKeyFromStandard =
             Convert.FromBase64String("uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBtbmHhIDi6pcl8jsasjlTMtDQ==");
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public HmacSha256SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         #region From standard
 
@@ -109,13 +118,13 @@ namespace NSign.Providers
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             HmacSha256SignatureProvider provider = Make();
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            provider.UpdateSignatureParams(signatureParams);
+            await provider.UpdateSignatureParamsAsync(signatureParams, this.messageContext, CancellationToken.None);
             Assert.Equal("hmac-sha256", signatureParams.Algorithm);
         }
 

--- a/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/RsaPkcs15Sha256SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -13,6 +15,13 @@ namespace NSign.Providers
     {
         private readonly Random rng = new Random();
         private readonly RSA publicKeyFromStandard = GetPublicKeyFromStandard();
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public RsaPkcs15Sha256SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         #region From standard
 
@@ -219,13 +228,13 @@ namespace NSign.Providers
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             RsaPkcs15Sha256SignatureProvider signingProvider = Make(true);
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            signingProvider.UpdateSignatureParams(signatureParams);
+            await signingProvider.UpdateSignatureParamsAsync(signatureParams, this.messageContext, CancellationToken.None);
             Assert.Equal("rsa-v1_5-sha256", signatureParams.Algorithm);
         }
 

--- a/test/NSign.SignatureProviders.UnitTests/Providers/RsaPssSha512SignatureProviderTests.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/RsaPssSha512SignatureProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using NSign.Signatures;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NSign.Signatures;
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -13,6 +15,13 @@ namespace NSign.Providers
     {
         private readonly Random rng = new Random();
         private readonly RSA publicKeyFromStandard = GetPublicKeyFromStandard();
+        private readonly Mock<ILogger> mockLogger = new Mock<ILogger>(MockBehavior.Loose);
+        private readonly TestMessageContext messageContext;
+
+        public RsaPssSha512SignatureProviderTests()
+        {
+            messageContext = new TestMessageContext(mockLogger.Object);
+        }
 
         #region From standard
 
@@ -223,13 +232,13 @@ aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
         }
 
         [Fact]
-        public void UpdateSignatureParamsSetsTheAlgorithm()
+        public async Task UpdateSignatureParamsSetsTheAlgorithm()
         {
             RsaPssSha512SignatureProvider signingProvider = Make(true);
             SignatureParamsComponent signatureParams = new SignatureParamsComponent();
 
             Assert.Null(signatureParams.Algorithm);
-            signingProvider.UpdateSignatureParams(signatureParams);
+            await signingProvider.UpdateSignatureParamsAsync(signatureParams, messageContext, CancellationToken.None);
             Assert.Equal("rsa-pss-sha512", signatureParams.Algorithm);
         }
 

--- a/test/NSign.SignatureProviders.UnitTests/Providers/TestMessageContext.cs
+++ b/test/NSign.SignatureProviders.UnitTests/Providers/TestMessageContext.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Extensions.Logging;
+using NSign.Http;
+using NSign.Signatures;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace NSign.Providers
+{
+    internal sealed class TestMessageContext : MessageContext
+    {
+        public TestMessageContext(ILogger logger) : base(logger, new HttpFieldOptions())
+        { }
+
+        internal bool HasResponseValue { get; set; }
+
+        internal CancellationToken AbortedValue { get; set; }
+
+        internal Action<string, string>? OnAddHeader { get; set; }
+
+        internal Func<DerivedComponent, string?>? OnGetDerivedComponentValue { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetHeaderValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetTrailerValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetRequestHeaderValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetRequestTrailerValues { get; set; }
+        internal Func<string, IEnumerable<string>>? OnGetQueryParamValues { get; set; }
+
+        public override bool HasResponse => HasResponseValue;
+
+        public override CancellationToken Aborted => AbortedValue;
+
+        public override void AddHeader(string headerName, string value)
+        {
+            OnAddHeader!(headerName, value);
+        }
+
+        public override string? GetDerivedComponentValue(DerivedComponent component)
+        {
+            return OnGetDerivedComponentValue!(component);
+        }
+
+        public override IEnumerable<string> GetHeaderValues(string headerName)
+        {
+            return OnGetHeaderValues!(headerName);
+        }
+
+        public override IEnumerable<string> GetTrailerValues(string fieldName)
+        {
+            return OnGetTrailerValues!(fieldName);
+        }
+
+        public override IEnumerable<string> GetQueryParamValues(string paramName)
+        {
+            return OnGetQueryParamValues!(paramName);
+        }
+
+        public override IEnumerable<string> GetRequestHeaderValues(string headerName)
+        {
+            return OnGetRequestHeaderValues!(headerName);
+        }
+
+        public override IEnumerable<string> GetRequestTrailerValues(string fieldName)
+        {
+            return OnGetRequestTrailerValues!(fieldName);
+        }
+    }
+}


### PR DESCRIPTION
Updated `UserBasedSignatureProvider` and `ISigner` interface to support asynchronous method signatures for `SignAsync` and `UpdateSignatureParams`. The `SignAsync` method now includes a `keyId` parameter, enhancing flexibility for user-specific signing operations.

Modified related classes (`SignatureProvider`, `DefaultMessageSigner`, and various signature provider implementations) to adopt the new async methods. Test classes have been updated accordingly to ensure proper testing of the new functionality.

Introduced a new `TestMessageContext` class for improved testing capabilities and updated project dependencies to include the `Moq` library for effective mocking in unit tests.